### PR TITLE
Add Scaling to Midterm and Fix Probabilistically Impossible when Grade is Possible

### DIFF
--- a/predict_70_final.py
+++ b/predict_70_final.py
@@ -87,7 +87,7 @@ def predict_final_std_exact(desired_std, mt1_raw, should_print=True, show_all=Fa
     for final_std in np.arange(-3, 3, 0.001):
         clobber = avg_std(mt1_std, final_std)
         delta = 0.01
-        overall_std = round(avg_std(max(mt1_std, clobber)*.75, max(final_std, clobber)), 2)
+        overall_std = round(avg_std(max(mt1_std, clobber)*.75, max(final_std, clobber)), 3)
 
         if abs(overall_std - desired_std) <= delta:
             overall_p = st.norm.cdf(overall_std) # converts to percentile in normalized distribution

--- a/predict_70_final.py
+++ b/predict_70_final.py
@@ -63,10 +63,13 @@ def predict_final_std_all(mt1_raw):
         grade_range = grade_to_z(grade)
         lower = predict_final_std_exact(grade_range[0], mt1_raw, should_print=False, show_all=True)
         upper = predict_final_std_exact(grade_range[1], mt1_raw, should_print=False, show_all=True)
-        if type(lower) is str and type(upper) is str:
+        low_str = type(lower) is str
+        up_str = type(upper) is str
+        
+        if low_str and up_str:
             print(f"{grade}: Probabilistically Impossible")
         else: 
-            print(f'{grade}: ({lower},{upper})')
+            print(f'{grade}: ({"Cant reach lower bound" if low_str else lower},{"Cant reach upper bound" if up_str else upper})')
             
 
 def predict_final_std_range(grade, mt1_raw):

--- a/predict_70_final.py
+++ b/predict_70_final.py
@@ -63,7 +63,7 @@ def predict_final_std_all(mt1_raw):
         grade_range = grade_to_z(grade)
         lower = predict_final_std_exact(grade_range[0], mt1_raw, should_print=False, show_all=True)
         upper = predict_final_std_exact(grade_range[1], mt1_raw, should_print=False, show_all=True)
-        if type(upper) is str and type(lower) is str:
+        if type(lower) is str and type(upper) is str:
             print(f"{grade}: Probabilistically Impossible")
         else: 
             print(f'{grade}: ({lower},{upper})')

--- a/predict_70_final.py
+++ b/predict_70_final.py
@@ -63,7 +63,7 @@ def predict_final_std_all(mt1_raw):
         grade_range = grade_to_z(grade)
         lower = predict_final_std_exact(grade_range[0], mt1_raw, should_print=False, show_all=True)
         upper = predict_final_std_exact(grade_range[1], mt1_raw, should_print=False, show_all=True)
-        if type(upper) is str:
+        if type(upper) is str and type(lower) is str:
             print(f"{grade}: Probabilistically Impossible")
         else: 
             print(f'{grade}: ({lower},{upper})')

--- a/predict_70_final.py
+++ b/predict_70_final.py
@@ -63,7 +63,7 @@ def predict_final_std_all(mt1_raw):
         grade_range = grade_to_z(grade)
         lower = predict_final_std_exact(grade_range[0], mt1_raw, should_print=False, show_all=True)
         upper = predict_final_std_exact(grade_range[1], mt1_raw, should_print=False, show_all=True)
-        if type(lower) is str or type(upper) is str:
+        if type(upper) is str:
             print(f"{grade}: Probabilistically Impossible")
         else: 
             print(f'{grade}: ({lower},{upper})')
@@ -84,7 +84,7 @@ def predict_final_std_exact(desired_std, mt1_raw, should_print=True, show_all=Fa
     for final_std in np.arange(-3, 3, 0.001):
         clobber = avg_std(mt1_std, final_std)
         delta = 0.01
-        overall_std = round(avg_std(max(mt1_std, clobber), max(final_std, clobber)), 2)
+        overall_std = round(avg_std(max(mt1_std, clobber)*.75, max(final_std, clobber)), 2)
 
         if abs(overall_std - desired_std) <= delta:
             overall_p = st.norm.cdf(overall_std) # converts to percentile in normalized distribution


### PR DESCRIPTION
Added the 75% scaling to the MT.

Probabilistically Impossible is shown if either a lower or upper bound cannot be reached. This is bad behavior, because in this case the grade CAN be reached, just not the lower or upper bound of said grade. Changing the "or" to "and" fixes this issue, by showing the bound that can be reached, and showing "cant reach lower/upper bound" for said bound that cannot be reached.

New output looks as such:
<img width="560" alt="Screen Shot 2022-04-08 at 9 25 15 PM" src="https://user-images.githubusercontent.com/19242890/162556170-8ed29ae4-a9cb-4c51-a76a-401dec22b355.png">


